### PR TITLE
Update .gitignore to include development artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 config.ini
 constants.py
 servers.pickle
+__pycache__/
+.vscode/


### PR DESCRIPTION
I've updated the .gitignore file to include standard Python and editor artifacts that shouldn't be tracked in version control.

Changes

Added __pycache__/: To ignore Python compiled bytecode.

Added .vscode/: To ignore local VS Code editor settings/workspace configurations.

This helps keep the repository clean and prevents local environment files from being pushed by contributors.